### PR TITLE
add raw audio workaround in sample program

### DIFF
--- a/sample_program/meeting_bot.py
+++ b/sample_program/meeting_bot.py
@@ -247,6 +247,10 @@ class MeetingBot:
         self.audio_ctrl = self.meeting_service.GetMeetingAudioController()
         self.audio_ctrl_event = zoom.MeetingAudioCtrlEventCallbacks(onUserAudioStatusChangeCallback=self.on_user_audio_status_change_callback, onUserActiveAudioChangeCallback=self.on_user_active_audio_change_callback)
         self.audio_ctrl.SetEvent(self.audio_ctrl_event)
+        # Raw audio input got borked in the Zoom SDK after 6.3.5.
+        # This is work-around to get it to work again.
+        # See here for more details: https://devforum.zoom.us/t/cant-record-audio-with-linux-meetingsdk-after-6-3-5-6495-error-code-32/130689/5
+        self.audio_ctrl.JoinVoip()
         
         self.chat_ctrl = self.meeting_service.GetMeetingChatController()
         self.chat_ctrl_event = zoom.MeetingChatEventCallbacks(onChatMsgNotificationCallback=self.on_chat_msg_notification_callback)


### PR DESCRIPTION
Raw audio stopped working when run in the a docker container in SDK Version 6.3.5+. Calling JoinVoip() after you join the meeting gets it working again.

See here for more details: https://devforum.zoom.us/t/cant-record-audio-with-linux-meetingsdk-after-6-3-5-6495-error-code-32/130689/5
